### PR TITLE
removes icon ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ sites/simpletest
 ######################
 .DS_Store*
 ehthumbs.db
-Icon?
 
 Thumbs.db
 ._*


### PR DESCRIPTION
This causes an issue on both Drupal and Wordpress by excluding any folder from any module titled "icon" or "icons". This should be removed or the exclusion should be improved.